### PR TITLE
test(service): add unit tests across service layer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,6 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.9.22'
     id 'org.jetbrains.kotlin.plugin.spring' version '1.9.22'
     id 'org.jetbrains.kotlin.plugin.jpa' version '1.9.22'
-
 }
 
 group = 'com.example'
@@ -45,29 +44,46 @@ repositories {
 
 ext {
     set('snippetsDir', file("build/generated-snippets"))
+
+    set('springDataJdbcVersion', '3.2.2')
+    set('springdocOpenApiVersion', '2.3.0')
+    set('kotestVersion', '5.8.0')
+    set('kotestSpringExtensionVersion', '1.1.3')
+    set('mockkVersion', '1.13.8')
+    set('azureStorageBlobVersion', '12.27.1')
+    set('thumbnailatorVersion', '0.4.20')
+    set('kotlinStdlibVersion', '1.8.10')
+    set('mysqlConnectorVersion', '9.3.0')
+    set('mssqlJdbcVersion', '12.8.1.jre11')
 }
 
 dependencies {
-    implementation 'com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre11'
+    implementation "com.microsoft.sqlserver:mssql-jdbc:${mssqlJdbcVersion}"
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.fasterxml.jackson.module:jackson-module-kotlin'
-    implementation 'org.springframework.data:spring-data-jdbc:3.2.2'
+    implementation "org.springframework.data:spring-data-jdbc:${springDataJdbcVersion}"
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.jetbrains.kotlin:kotlin-reflect'
-    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0")
+    implementation "org.springdoc:springdoc-openapi-starter-webmvc-ui:${springdocOpenApiVersion}"
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    
+    testImplementation "io.kotest:kotest-runner-junit5:${kotestVersion}"
+    testImplementation "io.kotest:kotest-assertions-core:${kotestVersion}"
+    testImplementation "io.kotest:kotest-property:${kotestVersion}"
+    testImplementation "io.kotest.extensions:kotest-extensions-spring:${kotestSpringExtensionVersion}"
+    testImplementation "io.mockk:mockk:${mockkVersion}"
 
     implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
     implementation "org.springframework.boot:spring-boot-starter-security"
     implementation "org.springframework.boot:spring-boot-starter-oauth2-resource-server"
     implementation "org.springframework.security:spring-security-oauth2-jose"
 
-    implementation 'com.azure:azure-storage-blob:12.27.1'
-    implementation 'net.coobird:thumbnailator:0.4.20'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.8.10"
-    implementation 'com.mysql:mysql-connector-j:9.3.0'
+    implementation "com.azure:azure-storage-blob:${azureStorageBlobVersion}"
+    implementation "net.coobird:thumbnailator:${thumbnailatorVersion}"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:${kotlinStdlibVersion}"
+    implementation "com.mysql:mysql-connector-j:${mysqlConnectorVersion}"
 
 
 }

--- a/src/main/kotlin/com/example/autobank/service/AttachmentService.kt
+++ b/src/main/kotlin/com/example/autobank/service/AttachmentService.kt
@@ -7,10 +7,9 @@ import org.springframework.stereotype.Service
 
 
 @Service
-class AttachmentService {
-
-    @Autowired
-    lateinit var attachmentRepository: AttachmentRepository;
+class AttachmentService(
+    private val attachmentRepository: AttachmentRepository
+) {
 
     fun createAttachment(attachment: Attachment): Attachment {
         return attachmentRepository.save(attachment);

--- a/src/main/kotlin/com/example/autobank/service/AuthenticationService.kt
+++ b/src/main/kotlin/com/example/autobank/service/AuthenticationService.kt
@@ -104,7 +104,6 @@ class AuthenticationService(
         )
 
         if (response.statusCode.isError || response.body == null) {
-
             throw Exception("Error fetching user id")
         }
 
@@ -176,7 +175,7 @@ class AuthenticationService(
             } else {
                 null
             }
-    }
+        }
 
     data class Result(
         val name_long: String = ""

--- a/src/main/kotlin/com/example/autobank/service/CommitteeService.kt
+++ b/src/main/kotlin/com/example/autobank/service/CommitteeService.kt
@@ -3,17 +3,13 @@ package com.example.autobank.service;
 import com.example.autobank.data.models.Committee
 import com.example.autobank.data.user.UserCommitteeResponseBody
 import com.example.autobank.repository.CommitteeRepository
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
-class CommitteeService() {
-
-    @Autowired
-    lateinit var committeeRepository: CommitteeRepository
-
-    @Autowired
-    lateinit var authenticationService: AuthenticationService
+class CommitteeService(
+    private val committeeRepository: CommitteeRepository,
+    private val authenticationService: AuthenticationService
+) {
 
     fun getAllCommittees(): List<Committee> {
         return committeeRepository.findAll()

--- a/src/main/kotlin/com/example/autobank/service/EconomicrequestService.kt
+++ b/src/main/kotlin/com/example/autobank/service/EconomicrequestService.kt
@@ -7,13 +7,10 @@ import org.springframework.stereotype.Service
 
 
 @Service
-class EconomicrequestService {
-
-    @Autowired
-    lateinit var economicrequestRepository: EconomicrequestRepository
-
-    @Autowired
-    lateinit var onlineUserService: OnlineUserService
+class EconomicrequestService(
+    private val economicrequestRepository: EconomicrequestRepository,
+    private val onlineUserService: OnlineUserService
+) {
 
 
     fun deleteEconomicrequest(id: Int) {

--- a/src/main/kotlin/com/example/autobank/service/OnlineUserService.kt
+++ b/src/main/kotlin/com/example/autobank/service/OnlineUserService.kt
@@ -11,16 +11,9 @@ import java.time.LocalDateTime
 
 @Service
 class OnlineUserService(
+    private val authenticationService: AuthenticationService,
+    private val onlineUserRepository: OnlineUserRepository
 ) {
-
-    @Autowired
-    lateinit var authenticationService: AuthenticationService
-
-    @Autowired
-    lateinit var onlineUserRepository: OnlineUserRepository
-
-
-
 
     fun getOnlineUser(): OnlineUser? {
         val sub: String = authenticationService.getUserSub()

--- a/src/main/kotlin/com/example/autobank/service/ReceiptAdminService.kt
+++ b/src/main/kotlin/com/example/autobank/service/ReceiptAdminService.kt
@@ -13,14 +13,10 @@ import org.springframework.data.domain.Sort
 
 
 @Service
-class ReceiptAdminService {
-
-    @Autowired
-    lateinit var receiptInfoRepository: ReceiptInfoRepositoryImpl
-
-    @Autowired
-    lateinit var receiptService: ReceiptService
-
+class ReceiptAdminService(
+    private val receiptInfoRepository: ReceiptInfoRepositoryImpl,
+    private val receiptService: ReceiptService
+) {
 
     fun getAll(from: Int, count: Int, status: String?, committeeName: String?, search: String?, sortField: String?, sortOrder: String?): ReceiptListResponseBody? {
 

--- a/src/main/kotlin/com/example/autobank/service/ReceiptReviewService.kt
+++ b/src/main/kotlin/com/example/autobank/service/ReceiptReviewService.kt
@@ -10,16 +10,11 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 
 @Service
-class ReceiptReviewService {
-
-    @Autowired
-    lateinit var receiptReviewRepository: ReceiptReviewRepository
-
-    @Autowired
-    lateinit var onlineUserService: OnlineUserService
-
-    @Autowired
-    lateinit var receiptRepository: ReceiptRepository
+class ReceiptReviewService(
+    private val receiptReviewRepository: ReceiptReviewRepository,
+    private val onlineUserService: OnlineUserService,
+    private val receiptRepository: ReceiptRepository
+) {
 
     fun createReceiptReview(receiptReview: ReceiptReviewRequestBody): ReceiptReviewResponseBody {
         val onlineuser = onlineUserService.getOnlineUser() ?: throw Exception("User not found")

--- a/src/main/kotlin/com/example/autobank/service/ReceiptService.kt
+++ b/src/main/kotlin/com/example/autobank/service/ReceiptService.kt
@@ -5,32 +5,19 @@ import com.example.autobank.data.receipt.*
 import com.example.autobank.data.receipt.ReceiptInfoResponseBody
 import com.example.autobank.repository.receipt.*
 import com.example.autobank.repository.receipt.specification.ReceiptInfoViewSpecification
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Service
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort
 
 @Service
-
-class ReceiptService {
-
-    @Autowired
-    lateinit var onlineUserService: OnlineUserService
-
-    @Autowired
-    lateinit var receiptRepository: ReceiptRepository
-
-    @Autowired
-    lateinit var blobService: BlobService
-
-    @Autowired
-    lateinit var attachmentService: AttachmentService
-
-    @Autowired
-    lateinit var committeeService: CommitteeService
-
-    @Autowired
-    lateinit var receiptInfoRepository: ReceiptInfoRepositoryImpl
+class ReceiptService(
+    private val onlineUserService: OnlineUserService,
+    private val receiptRepository: ReceiptRepository,
+    private val blobService: BlobService,
+    private val attachmentService: AttachmentService,
+    private val committeeService: CommitteeService,
+    private val receiptInfoRepository: ReceiptInfoRepositoryImpl
+) {
 
 
     fun createReceipt(receiptRequestBody: ReceiptRequestBody): ReceiptResponseBody {
@@ -147,11 +134,6 @@ class ReceiptService {
         }
 
         return getCompleteReceipt(receipt)
-
-
-
-
-
     }
 
     fun getCompleteReceipt(receipt: ReceiptInfo): CompleteReceipt {

--- a/src/test/kotlin/com/example/autobank/service/AttachmentServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/AttachmentServiceTest.kt
@@ -1,0 +1,90 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.models.Attachment
+import com.example.autobank.data.models.Committee
+import com.example.autobank.data.models.Receipt
+import com.example.autobank.data.user.OnlineUser
+import com.example.autobank.repository.receipt.AttachmentRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class AttachmentServiceTest : FunSpec({
+
+    val attachmentRepository = mockk<AttachmentRepository>()
+    val attachmentService = AttachmentService(attachmentRepository)
+
+    context("createAttachment") {
+        test("should create attachment successfully") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                "receipt-1", 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now()
+            )
+            val attachment = Attachment(
+                "attachment-1", mockReceipt, "test-file.jpg"
+            )
+            
+            every { attachmentRepository.save(attachment) } returns attachment
+
+            // When
+            val result = attachmentService.createAttachment(attachment)
+
+            // Then
+            result shouldNotBe null
+            result shouldBe attachment
+            result.id shouldBe "attachment-1"
+            result.name shouldBe "test-file.jpg"
+            verify { attachmentRepository.save(attachment) }
+        }
+    }
+
+    context("getAttachmentsByReceiptId") {
+        test("should return attachments for existing receipt") {
+            // Given
+            val receiptId = "receipt-1"
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = com.example.autobank.data.models.Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                receiptId, 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now()
+            )
+            val attachments = listOf(
+                Attachment("attachment-1", mockReceipt, "file1.jpg"),
+                Attachment("attachment-2", mockReceipt, "file2.pdf")
+            )
+            
+            every { attachmentRepository.findByReceiptId(receiptId) } returns attachments
+
+            // When
+            val result = attachmentService.getAttachmentsByReceiptId(receiptId)
+
+            // Then
+            result shouldNotBe null
+            result.size shouldBe 2
+            result[0].name shouldBe "file1.jpg"
+            result[1].name shouldBe "file2.pdf"
+            verify { attachmentRepository.findByReceiptId(receiptId) }
+        }
+
+        test("should return empty list for receipt with no attachments") {
+            // Given
+            val receiptId = "receipt-without-attachments"
+            every { attachmentRepository.findByReceiptId(receiptId) } returns emptyList()
+
+            // When
+            val result = attachmentService.getAttachmentsByReceiptId(receiptId)
+
+            // Then
+            result shouldNotBe null
+            result shouldBe emptyList()
+            verify { attachmentRepository.findByReceiptId(receiptId) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/AuthenticationServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/AuthenticationServiceTest.kt
@@ -1,0 +1,131 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.user.OnlineUser
+import com.example.autobank.repository.user.OnlineUserRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.assertThrows
+import java.time.Instant
+import java.time.LocalDateTime
+
+class AuthenticationServiceTest : FunSpec({
+
+    val onlineUserRepository = mockk<OnlineUserRepository>()
+    val authenticationService = AuthenticationService(
+        adminCommittee = "Test Committee",
+        domain = "test.auth0.com",
+        environment = "test"
+    ).apply {
+        this.onlineUserRepository = onlineUserRepository
+    }
+
+    context("getAuth0User") {
+        test("should return Auth0User with provided token") {
+            // Given
+            val token = "test-token"
+
+            // When
+            val result = authenticationService.getAuth0User(token)
+
+            // Then
+            result shouldNotBe null
+            result.sub shouldBe "sub"
+            result.email shouldBe "email"
+            result.name shouldBe "name"
+        }
+    }
+
+    context("getUserSub") {
+        test("should return empty string when no authentication context") {
+            // When
+            val result = authenticationService.getUserSub()
+
+            // Then
+            result shouldBe ""
+        }
+    }
+
+    context("getFullName") {
+        test("should return empty string") {
+            // When
+            val result = authenticationService.getFullName()
+
+            // Then
+            result shouldBe ""
+        }
+    }
+
+    context("getAccessToken") {
+        test("should return empty string when no authentication context") {
+            // When
+            val result = authenticationService.getAccessToken()
+
+            // Then
+            result shouldBe ""
+        }
+    }
+
+    context("checkAdmin") {
+        test("should return true for admin user") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", true, LocalDateTime.now())
+            every { onlineUserRepository.findByOnlineId(any()) } returns mockUser
+
+            // When
+            val result = authenticationService.checkAdmin()
+
+            // Then
+            result shouldBe true
+            verify { onlineUserRepository.findByOnlineId(any()) }
+        }
+        test("should throw Exception when user not found") {
+            // Given
+            every { onlineUserRepository.findByOnlineId(any()) } returns null
+
+            // When & Then
+            val exception = assertThrows<Exception> { authenticationService.checkAdmin() }
+            exception.message shouldBe "User not found"
+        }
+    }
+
+    context("getExpiresAt") {
+        test("should return null when no authentication context") {
+            // When
+            val result = authenticationService.getExpiresAt()
+
+            // Then
+            result shouldBe null
+        }
+    }
+
+    context("fetchUserCommittees") {
+        test("should return test committees in dev environment") {
+            // Given
+            val testService = AuthenticationService(
+                adminCommittee = "Test Committee",
+                domain = "test.auth0.com",
+                environment = "dev" // Non-prod environment
+            )
+
+            // When
+            val result = testService.fetchUserCommittees()
+
+            // Then
+            result shouldBe listOf("Applikasjonskomiteen", "Trivselskomiteen")
+        }
+    }
+
+    context("getSecondsUntilExpiration") {
+        test("should return 0 when no expiration time") {
+            // When
+            val result = authenticationService.getSecondsUntilExpiration()
+
+            // Then
+            result shouldBe 0
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/CommitteeServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/CommitteeServiceTest.kt
@@ -1,0 +1,105 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.authentication.Auth0User
+import com.example.autobank.data.models.Committee
+import com.example.autobank.data.user.UserCommitteeResponseBody
+import com.example.autobank.repository.CommitteeRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.*
+
+class CommitteeServiceTest : FunSpec({
+
+    val committeeRepository = mockk<CommitteeRepository>()
+    val authenticationService = mockk<AuthenticationService>()
+    val committeeService = CommitteeService(committeeRepository, authenticationService)
+
+    context("getAllCommittees") {
+        test("should return all committees") {
+            // Given
+            val expectedCommittees = listOf(
+                Committee("1", "Applikasjonskomiteen"),
+                Committee("2", "Trivselskomiteen")
+            )
+            every { committeeRepository.findAll() } returns expectedCommittees
+
+            // When
+            val result = committeeService.getAllCommittees()
+
+            // Then
+            result shouldBe expectedCommittees
+            verify { committeeRepository.findAll() }
+        }
+
+        test("should return empty list when no committees exist") {
+            // Given
+            every { committeeRepository.findAll() } returns emptyList()
+
+            // When
+            val result = committeeService.getAllCommittees()
+
+            // Then
+            result shouldBe emptyList()
+        }
+    }
+
+    context("getUserAndCommittees") {
+        test("should return user information and committee list") {
+            // Given
+            val mockUserDetails = Auth0User(
+                sub = "test-sub",
+                email = "test@example.com",
+                name = "Test User"
+            )
+            val mockCommittees = listOf("Applikasjonskomiteen", "Trivselskomiteen")
+            
+            every { authenticationService.getUserDetails() } returns mockUserDetails
+            every { authenticationService.fetchUserCommittees() } returns mockCommittees
+
+            // When
+            val result = committeeService.getUserAndCommittees()
+
+            // Then
+            result shouldBe UserCommitteeResponseBody(
+                name = "Test User",
+                email = "test@example.com",
+                committees = mockCommittees
+            )
+            verify { authenticationService.getUserDetails() }
+            verify { authenticationService.fetchUserCommittees() }
+        }
+    }
+
+    context("getCommitteeById") {
+        test("should find committee by existing ID") {
+            // Given
+            val committeeId = "1"
+            val expectedCommittee = Committee("1", "Applikasjonskomiteen")
+            every { committeeRepository.findById(committeeId) } returns Optional.of(expectedCommittee)
+
+            // When
+            val result = committeeService.getCommitteeById(committeeId)
+
+            // Then
+            result shouldBe expectedCommittee
+            verify { committeeRepository.findById(committeeId) }
+        }
+
+        test("should return null for non-existing committee ID") {
+            // Given
+            val committeeId = "999"
+            every { committeeRepository.findById(committeeId) } returns Optional.empty()
+
+            // When
+            val result = committeeService.getCommitteeById(committeeId)
+
+            // Then
+            result shouldBe null
+            verify { committeeRepository.findById(committeeId) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/EconomicrequestServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/EconomicrequestServiceTest.kt
@@ -1,0 +1,83 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.models.Economicrequest
+import com.example.autobank.data.user.OnlineUser
+import com.example.autobank.repository.EconomicrequestRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.math.BigDecimal
+import java.time.LocalDateTime
+import java.util.*
+
+class EconomicrequestServiceTest : FunSpec({
+
+    val economicrequestRepository = mockk<EconomicrequestRepository>()
+    val onlineUserService = mockk<OnlineUserService>()
+    val economicrequestService = EconomicrequestService(economicrequestRepository, onlineUserService)
+
+    context("deleteEconomicrequest") {
+        test("should delete economic request successfully") {
+            // Given
+            val requestId = 1
+            every { economicrequestRepository.deleteById(requestId) } returns Unit
+
+            // When
+            economicrequestService.deleteEconomicrequest(requestId)
+
+            // Then
+            verify { economicrequestRepository.deleteById(requestId) }
+        }
+    }
+
+    context("getEconomicrequest") {
+        test("should return economic request when found") {
+            // Given
+            val requestId = 1
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val economicrequest = Economicrequest(
+                id = requestId.toString(),
+                subject = "Test Subject",
+                purpose = "Test Purpose",
+                date = LocalDateTime.now(),
+                duration = "1 hour",
+                description = "Test Description",
+                amount = BigDecimal.valueOf(5000.0),
+                personCount = 1,
+                names = "Test User",
+                paymentDescription = "Test Payment",
+                otherInformation = "Test Info",
+                createdat = LocalDateTime.now(),
+                user = mockUser
+            )
+            
+            every { economicrequestRepository.findById(requestId) } returns Optional.of(economicrequest)
+
+            // When
+            val result = economicrequestService.getEconomicrequest(requestId)
+
+            // Then
+            result shouldNotBe null
+            result shouldBe economicrequest
+            result.id shouldBe requestId.toString()
+            result.subject shouldBe "Test Subject"
+            result.description shouldBe "Test Description"
+            result.amount shouldBe BigDecimal.valueOf(5000.0)
+            verify { economicrequestRepository.findById(requestId) }
+        }
+
+
+        test("should throw NoSuchElementException when request not found") {
+            // Given
+            val requestId = 999
+            every { economicrequestRepository.findById(requestId) } returns Optional.empty()
+
+            // When
+            shouldThrow<NoSuchElementException> { economicrequestService.getEconomicrequest(requestId) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/OnlineUserServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/OnlineUserServiceTest.kt
@@ -1,0 +1,142 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.authentication.Auth0User
+import com.example.autobank.data.authentication.AuthenticatedUserResponse
+import com.example.autobank.data.user.OnlineUser
+import com.example.autobank.repository.user.OnlineUserRepository
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.Instant
+import java.time.LocalDateTime
+
+class OnlineUserServiceTest : FunSpec({
+
+    val authenticationService = mockk<AuthenticationService>()
+    val onlineUserRepository = mockk<OnlineUserRepository>()
+    
+    val onlineUserService = OnlineUserService(authenticationService, onlineUserRepository)
+
+    context("getOnlineUser") {
+        test("should return user when found") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            every { authenticationService.getUserSub() } returns "test-sub"
+            every { onlineUserRepository.findByOnlineId("test-sub") } returns mockUser
+
+            // When
+            val result = onlineUserService.getOnlineUser()
+
+            // Then
+            result shouldNotBe null
+            result shouldBe mockUser
+            verify { authenticationService.getUserSub() }
+            verify { onlineUserRepository.findByOnlineId("test-sub") }
+        }
+
+        test("should return null when user not found") {
+            // Given
+            every { authenticationService.getUserSub() } returns "test-sub"
+            every { onlineUserRepository.findByOnlineId("test-sub") } returns null
+
+            // When
+            val result = onlineUserService.getOnlineUser()
+
+            // Then
+            result shouldBe null
+            verify { authenticationService.getUserSub() }
+            verify { onlineUserRepository.findByOnlineId("test-sub") }
+        }
+    }
+
+    context("checkUser") {
+        test("should return success response when user exists") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockExpiresAt = Instant.now().plusSeconds(3600)
+            
+            every { authenticationService.getUserSub() } returns "test-sub"
+            every { onlineUserRepository.findByOnlineId("test-sub") } returns mockUser
+            every { authenticationService.checkAdmin() } returns true
+            every { authenticationService.getExpiresAt() } returns mockExpiresAt
+            every { authenticationService.getFullName() } returns "Test User"
+
+            // When
+            val result = onlineUserService.checkUser()
+
+            // Then
+            result shouldNotBe null
+            result.success shouldBe true
+            result.isadmin shouldBe true
+            result.expiresat shouldBe mockExpiresAt
+            result.fullname shouldBe "Test User"
+            verify { authenticationService.getUserSub() }
+            verify { onlineUserRepository.findByOnlineId("test-sub") }
+        }
+
+        test("should create user and return success when user does not exist") {
+            // Given
+            val mockAuth0User = Auth0User("test-sub", "test@example.com", "Test User")
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockExpiresAt = Instant.now().plusSeconds(3600)
+            
+            every { authenticationService.getUserSub() } returns "test-sub"
+            every { onlineUserRepository.findByOnlineId("test-sub") } returns null
+            every { authenticationService.getUserDetails() } returns mockAuth0User
+            every { onlineUserRepository.save(any()) } returns mockUser
+            every { authenticationService.checkAdmin() } returns false
+            every { authenticationService.getExpiresAt() } returns mockExpiresAt
+            every { authenticationService.getFullName() } returns "Test User"
+
+            // When
+            val result = onlineUserService.checkUser()
+
+            // Then
+            result shouldNotBe null
+            result.success shouldBe true
+            result.isadmin shouldBe false
+            verify { authenticationService.getUserDetails() }
+            verify { onlineUserRepository.save(any()) }
+        }
+
+        test("should return failure response when user creation fails") {
+            // Given
+            every { authenticationService.getUserSub() } returns "test-sub"
+            every { onlineUserRepository.findByOnlineId("test-sub") } returns null
+            every { authenticationService.getUserDetails() } throws Exception("API Error")
+
+            // When
+            val result = onlineUserService.checkUser()
+
+            // Then
+            result shouldNotBe null
+            result.success shouldBe false
+            result.isadmin shouldBe false
+            result.expiresat shouldBe null
+            result.fullname shouldBe ""
+        }
+    }
+
+    context("createOnlineUser") {
+        test("should create and return online user") {
+            // Given
+            val mockAuth0User = Auth0User("test-sub", "test@example.com", "Test User")
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            
+            every { authenticationService.getUserDetails() } returns mockAuth0User
+            every { onlineUserRepository.save(any()) } returns mockUser
+
+            // When
+            val result = onlineUserService.createOnlineUser()
+
+            // Then
+            result shouldNotBe null
+            result shouldBe mockUser
+            verify { authenticationService.getUserDetails() }
+            verify { onlineUserRepository.save(any()) }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/ReceiptAdminServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/ReceiptAdminServiceTest.kt
@@ -1,0 +1,148 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.models.*
+import com.example.autobank.data.receipt.*
+import com.example.autobank.repository.receipt.*
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+
+class ReceiptAdminServiceTest : FunSpec({
+
+    val receiptInfoRepository = mockk<ReceiptInfoRepositoryImpl>()
+    val receiptService = mockk<ReceiptService>()
+    
+    val receiptAdminService = ReceiptAdminService(receiptInfoRepository, receiptService)
+
+    context("getAll") {
+        test("should return all receipts with pagination") {
+            // Given
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 2L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns listOf(mockReceiptInfo)
+                every { totalElements } returns 1L
+            }
+
+            // When
+            val result = receiptAdminService.getAll(0, 10, null, null, null, null, null)
+
+            // Then
+            result shouldNotBe null
+            result?.receipts?.size shouldBe 1
+            result?.total shouldBe 1L
+            verify { receiptInfoRepository.findAll(any(), any()) }
+        }
+
+        test("should return empty list when no receipts found") {
+            // Given
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptAdminService.getAll(0, 10, null, null, null, null, null)
+
+            // Then
+            result shouldNotBe null
+            result?.receipts?.size shouldBe 0
+            result?.total shouldBe 0L
+        }
+
+        test("should apply sorting when sortField is provided") {
+            // Given
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptAdminService.getAll(0, 10, null, null, null, "amount", "DESC")
+
+            // Then
+            result shouldNotBe null
+            verify { receiptInfoRepository.findAll(any(), any()) }
+        }
+
+        test("should apply default sorting when sortField is null") {
+            // Given
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptAdminService.getAll(0, 10, null, null, null, null, null)
+
+            // Then
+            result shouldNotBe null
+            verify { receiptInfoRepository.findAll(any(), any()) }
+        }
+    }
+
+    context("getReceipt") {
+        test("should return complete receipt when found") {
+            // Given
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 2L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            val mockCompleteReceipt = mockk<CompleteReceipt>()
+            
+            every { receiptInfoRepository.findById("receipt-1") } returns mockReceiptInfo
+            every { receiptService.getCompleteReceipt(mockReceiptInfo) } returns mockCompleteReceipt
+
+            // When
+            val result = receiptAdminService.getReceipt("receipt-1")
+
+            // Then
+            result shouldNotBe null
+            result shouldBe mockCompleteReceipt
+            verify { receiptInfoRepository.findById("receipt-1") }
+            verify { receiptService.getCompleteReceipt(mockReceiptInfo) }
+        }
+
+        test("should return null when receipt not found") {
+            // Given
+            every { receiptInfoRepository.findById("receipt-999") } returns null
+
+            // When
+            val result = receiptAdminService.getReceipt("receipt-999")
+
+            // Then
+            result shouldBe null
+            verify { receiptInfoRepository.findById("receipt-999") }
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/ReceiptReviewServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/ReceiptReviewServiceTest.kt
@@ -1,0 +1,152 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.ReceiptReviewRequestBody
+import com.example.autobank.data.models.*
+import com.example.autobank.data.receipt.ReceiptReviewResponseBody
+import com.example.autobank.data.user.OnlineUser
+import com.example.autobank.repository.receipt.ReceiptRepository
+import com.example.autobank.repository.receipt.ReceiptReviewRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.time.LocalDateTime
+import java.util.*
+
+class ReceiptReviewServiceTest : FunSpec({
+
+    val receiptReviewRepository = mockk<ReceiptReviewRepository>()
+    val onlineUserService = mockk<OnlineUserService>()
+    val receiptRepository = mockk<ReceiptRepository>()
+    
+    val receiptReviewService = ReceiptReviewService(receiptReviewRepository, onlineUserService, receiptRepository)
+
+    context("createReceiptReview") {
+        test("should create new receipt review successfully") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                "receipt-1", 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now()
+            )
+            val mockReceiptReview = ReceiptReview(
+                "review-1", mockReceipt, ReceiptStatus.APPROVED, "Good receipt", mockUser, LocalDateTime.now()
+            )
+            
+            val receiptReviewRequest = ReceiptReviewRequestBody(
+                receiptId = "receipt-1",
+                status = "APPROVED",
+                comment = "Good receipt"
+            )
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptRepository.findById("receipt-1") } returns Optional.of(mockReceipt)
+            every { receiptReviewRepository.findFirstByReceiptId("receipt-1") } returns null
+            every { receiptReviewRepository.save(any()) } returns mockReceiptReview
+
+            // When
+            val result = receiptReviewService.createReceiptReview(receiptReviewRequest)
+
+            // Then
+            result shouldNotBe null
+            result.id shouldBe "review-1"
+            result.receiptId shouldBe "receipt-1"
+            result.status shouldBe ReceiptStatus.APPROVED
+            result.comment shouldBe "Good receipt"
+            result.onlineUserId shouldBe "1"
+            verify { onlineUserService.getOnlineUser() }
+            verify { receiptRepository.findById("receipt-1") }
+            verify { receiptReviewRepository.save(any()) }
+        }
+
+        test("should update existing receipt review") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                "receipt-1", 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now()
+            )
+            val existingReview = ReceiptReview(
+                "old-review-1", mockReceipt, ReceiptStatus.DENIED, "Old comment", mockUser, LocalDateTime.now()
+            )
+            val newReview = ReceiptReview(
+                "review-1", mockReceipt, ReceiptStatus.APPROVED, "Updated comment", mockUser, LocalDateTime.now()
+            )
+            
+            val receiptReviewRequest = ReceiptReviewRequestBody(
+                receiptId = "receipt-1",
+                status = "APPROVED",
+                comment = "Updated comment"
+            )
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptRepository.findById("receipt-1") } returns Optional.of(mockReceipt)
+            every { receiptReviewRepository.findFirstByReceiptId("receipt-1") } returns existingReview
+            every { receiptReviewRepository.deleteByReceiptId("receipt-1") } returns Unit
+            every { receiptReviewRepository.save(any()) } returns newReview
+
+            // When
+            val result = receiptReviewService.createReceiptReview(receiptReviewRequest)
+
+            // Then
+            result shouldNotBe null
+            result.status shouldBe ReceiptStatus.APPROVED
+            result.comment shouldBe "Updated comment"
+            verify { receiptReviewRepository.deleteByReceiptId("receipt-1") }
+            verify { receiptReviewRepository.save(any()) }
+        }
+
+        test("should throw Exception when user not found") {
+            // Given
+            val receiptReviewRequest = ReceiptReviewRequestBody(
+                receiptId = "receipt-1",
+                status = "APPROVED",
+                comment = "Good receipt"
+            )
+            
+            every { onlineUserService.getOnlineUser() } returns null
+
+            // When & Then
+            val exception = shouldThrow<Exception> { receiptReviewService.createReceiptReview(receiptReviewRequest) }
+            exception.message shouldBe "User not found"
+        }
+
+        test("should throw Exception when receipt not found") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptReviewRequest = ReceiptReviewRequestBody(
+                receiptId = "receipt-999",
+                status = "APPROVED",
+                comment = "Good receipt"
+            )
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptRepository.findById("receipt-999") } returns Optional.empty()
+
+            // When & Then
+            val exception = shouldThrow<Exception> { receiptReviewService.createReceiptReview(receiptReviewRequest) }
+            exception.message shouldBe "Receipt not found"
+        }
+
+        test("should throw Exception when status is invalid") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptReviewRequest = ReceiptReviewRequestBody(
+                receiptId = "receipt-1",
+                status = "INVALID_STATUS",
+                comment = "Good receipt"
+            )
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+
+            // When & Then
+            val exception = shouldThrow<Exception> { receiptReviewService.createReceiptReview(receiptReviewRequest) }
+            exception.message shouldBe "Invalid status"
+        }
+    }
+})

--- a/src/test/kotlin/com/example/autobank/service/ReceiptServiceTest.kt
+++ b/src/test/kotlin/com/example/autobank/service/ReceiptServiceTest.kt
@@ -1,0 +1,641 @@
+package com.example.autobank.service
+
+import com.example.autobank.data.models.*
+import com.example.autobank.data.receipt.*
+import com.example.autobank.data.user.OnlineUser
+import com.example.autobank.repository.receipt.*
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.assertThrows
+import java.time.LocalDateTime
+
+class ReceiptServiceTest : FunSpec({
+
+    val onlineUserService = mockk<OnlineUserService>()
+    val receiptRepository = mockk<ReceiptRepository>()
+    val blobService = mockk<BlobService>()
+    val attachmentService = mockk<AttachmentService>()
+    val committeeService = mockk<CommitteeService>()
+    val receiptInfoRepository = mockk<ReceiptInfoRepositoryImpl>()
+    
+    val receiptService = ReceiptService(
+        onlineUserService,
+        receiptRepository,
+        blobService,
+        attachmentService,
+        committeeService,
+        receiptInfoRepository
+    )
+
+    context("createReceipt") {
+        test("should create receipt successfully with card number") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                "receipt-1", 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now(),
+                card_number = "1234-5678-9012-3456",
+                account_number = null
+            )
+            val mockAttachment = Attachment("attachment-1", mockReceipt, "test-file.jpg")
+            
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns "1234-5678-9012-3456"
+                    every { accountnumber } returns null
+                    every { usedOnlineCard } returns true
+                }
+                every { attachments } returns arrayOf("base64-image-data")
+            }
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { committeeService.getCommitteeById("1") } returns mockCommittee
+            every { receiptRepository.save(any()) } returns mockReceipt
+            every { blobService.uploadFile("base64-image-data") } returns "test-file.jpg"
+            every { attachmentService.createAttachment(any()) } returns mockAttachment
+
+            // When
+            val result = receiptService.createReceipt(receiptRequestBody)
+
+            // Then
+            result shouldNotBe null
+            verify { onlineUserService.getOnlineUser() }
+            verify { committeeService.getCommitteeById("1") }
+            verify { receiptRepository.save(any()) }
+            verify { blobService.uploadFile("base64-image-data") }
+            verify { attachmentService.createAttachment(any()) }
+        }
+
+        test("should create receipt successfully with account number") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                "receipt-1", 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now(),
+                card_number = null,
+                account_number = "12345678901"
+            )
+            
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns null
+                    every { accountnumber } returns "12345678901"
+                    every { usedOnlineCard } returns false
+                }
+                every { attachments } returns arrayOf()
+            }
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { committeeService.getCommitteeById("1") } returns mockCommittee
+            every { receiptRepository.save(any()) } returns mockReceipt
+
+            // When
+            val result = receiptService.createReceipt(receiptRequestBody)
+
+            // Then
+            result shouldNotBe null
+            verify { onlineUserService.getOnlineUser() }
+            verify { committeeService.getCommitteeById("1") }
+            verify { receiptRepository.save(any()) }
+        }
+
+        test("should throw Exception when user not found") {
+            // Given
+            val receiptRequestBody = mockk<ReceiptRequestBody>()
+            every { onlineUserService.getOnlineUser() } returns null
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "User not found"
+            verify { onlineUserService.getOnlineUser() }
+        }
+
+        test("should throw Exception when receipt not sent") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns null
+            }
+            every { onlineUserService.getOnlineUser() } returns mockUser
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Receipt not sent"
+            verify { onlineUserService.getOnlineUser() }
+        }
+
+        test("should throw Exception when no payment information provided") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns null
+                    every { accountnumber } returns null
+                    every { usedOnlineCard } returns false
+                }
+            }
+            every { onlineUserService.getOnlineUser() } returns mockUser
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Card number or account number must be provided"
+            verify { onlineUserService.getOnlineUser() }
+        }
+
+        test("should throw Exception when both card and account number provided") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns "1234-5678-9012-3456"
+                    every { accountnumber } returns "12345678901"
+                    every { usedOnlineCard } returns true
+                }
+            }
+            every { onlineUserService.getOnlineUser() } returns mockUser
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Card and account number can not both be provided"
+            verify { onlineUserService.getOnlineUser() }
+        }
+
+        test("should throw Exception when committee ID not provided") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns null
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns "1234-5678-9012-3456"
+                    every { accountnumber } returns null
+                    every { usedOnlineCard } returns true
+                }
+            }
+            every { onlineUserService.getOnlineUser() } returns mockUser
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Committee ID not provided"
+            verify { onlineUserService.getOnlineUser() }
+        }
+
+        test("should throw Exception when committee not found") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns "1234-5678-9012-3456"
+                    every { accountnumber } returns null
+                    every { usedOnlineCard } returns true
+                }
+            }
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { committeeService.getCommitteeById("1") } returns null
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Committee not found"
+            verify { onlineUserService.getOnlineUser() }
+            verify { committeeService.getCommitteeById("1") }
+        }
+
+        test("should throw Exception when amount not provided") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns null
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns "1234-5678-9012-3456"
+                    every { accountnumber } returns null
+                    every { usedOnlineCard } returns true
+                }
+            }
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { committeeService.getCommitteeById("1") } returns mockCommittee
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Amount not provided"
+            verify { onlineUserService.getOnlineUser() }
+            verify { committeeService.getCommitteeById("1") }
+        }
+
+        test("should handle attachment upload failure and rollback") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockCommittee = Committee("1", "Test Committee")
+            val mockReceipt = Receipt(
+                "receipt-1", 1000.0, mockCommittee, "Test Receipt", "Test Description",
+                mockUser, emptySet(), emptySet(), LocalDateTime.now(),
+                card_number = "1234-5678-9012-3456",
+                account_number = null
+            )
+            
+            val receiptRequestBody = mockk<ReceiptRequestBody> {
+                every { receipt } returns mockk<ReceiptDTO> {
+                    every { amount } returns 1000.0
+                    every { name } returns "Test Receipt"
+                    every { description } returns "Test Description"
+                    every { committee_id } returns "1"
+                }
+                every { receiptPaymentInformation } returns mockk<ReceiptPaymentInformation> {
+                    every { cardnumber } returns "1234-5678-9012-3456"
+                    every { accountnumber } returns null
+                    every { usedOnlineCard } returns true
+                }
+                every { attachments } returns arrayOf("invalid-base64-data")
+            }
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { committeeService.getCommitteeById("1") } returns mockCommittee
+            every { receiptRepository.save(any()) } returns mockReceipt
+            every { blobService.uploadFile("invalid-base64-data") } throws Exception("Invalid file format")
+            every { receiptRepository.delete(mockReceipt) } returns Unit
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.createReceipt(receiptRequestBody) }
+            exception.message shouldBe "Invalid file format"
+            verify { onlineUserService.getOnlineUser() }
+            verify { committeeService.getCommitteeById("1") }
+            verify { receiptRepository.save(any()) }
+            verify { blobService.uploadFile("invalid-base64-data") }
+            verify { receiptRepository.delete(mockReceipt) }
+        }
+    }
+    
+    context("getAllReceiptsFromUser") {
+        test("should return all receipts for user") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptService.getAllReceiptsFromUser(0, 10, null, null, null, null, null)
+
+            // Then
+            result shouldNotBe null
+            result?.receipts shouldBe emptyArray()
+            result?.total shouldBe 0L
+            verify { onlineUserService.getOnlineUser() }
+        }
+
+        test("should return receipts with pagination") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 2L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns listOf(mockReceiptInfo)
+                every { totalElements } returns 1L
+            }
+
+            // When
+            val result = receiptService.getAllReceiptsFromUser(0, 10, null, null, null, null, null)
+
+            // Then
+            result shouldNotBe null
+            result?.receipts?.size shouldBe 1
+            result?.total shouldBe 1L
+        }
+
+        test("should apply sorting when sortField is provided") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptService.getAllReceiptsFromUser(0, 10, null, null, null, "amount", "DESC")
+
+            // Then
+            result shouldNotBe null
+            verify { receiptInfoRepository.findAll(any(), any()) }
+        }
+
+        test("should apply default sorting when sortField is null") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptService.getAllReceiptsFromUser(0, 10, null, null, null, null, null)
+
+            // Then
+            result shouldNotBe null
+            verify { receiptInfoRepository.findAll(any(), any()) }
+        }
+
+        test("should apply filters when provided") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findAll(any(), any()) } returns mockk {
+                every { toList() } returns emptyList()
+                every { totalElements } returns 0L
+            }
+
+            // When
+            val result = receiptService.getAllReceiptsFromUser(0, 10, "APPROVED", "Test Committee", "search term", null, null)
+
+            // Then
+            result shouldNotBe null
+            verify { receiptInfoRepository.findAll(any(), any()) }
+        }
+
+        test("should throw Exception when user is not found") {
+            // Given
+            every { onlineUserService.getOnlineUser() } returns null
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.getAllReceiptsFromUser(0, 10, null, null, null, null, null) }
+            exception.message shouldBe "User not found"
+        }
+    }
+
+    context("getReceipt") {
+        test("should return existing receipt") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { userId } returns "1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 0L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findById("receipt-1") } returns mockReceiptInfo
+            every { attachmentService.getAttachmentsByReceiptId("receipt-1") } returns emptyList()
+            every { blobService.downloadImage(any()) } returns "test-file.jpg"
+
+            // When
+            val result = receiptService.getReceipt("receipt-1")
+
+            // Then
+            result shouldNotBe null
+            verify { onlineUserService.getOnlineUser() }
+            verify { receiptInfoRepository.findById("receipt-1") }
+        }
+
+        test("should throw Exception when user is not found") {
+            // Given
+            every { onlineUserService.getOnlineUser() } returns null
+
+            // When & Then
+            val exception = assertThrows<Exception> { receiptService.getReceipt("receipt-1") }
+            exception.message shouldBe "User not found"
+        }
+
+        test("should return null for another user's receipt") {
+            // Given
+            val mockUser = OnlineUser("1", "test-sub", "Test User", "test@example.com", false, LocalDateTime.now())
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { userId } returns "2" // Different user
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 0L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            every { onlineUserService.getOnlineUser() } returns mockUser
+            every { receiptInfoRepository.findById("receipt-1") } returns mockReceiptInfo
+
+            // When
+            val result = receiptService.getReceipt("receipt-1")
+
+            // Then
+            result shouldBe null
+        }
+    }
+
+    context("getCompleteReceipt") {
+        test("should return complete receipt with attachments") {
+            // Given
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 2L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            val mockAttachment = mockk<Attachment> {
+                every { name } returns "test-file.jpg"
+            }
+            
+            every { attachmentService.getAttachmentsByReceiptId("receipt-1") } returns listOf(mockAttachment)
+            every { blobService.downloadImage("test-file.jpg") } returns "base64data"
+
+            // When
+            val result = receiptService.getCompleteReceipt(mockReceiptInfo)
+
+            // Then
+            result shouldNotBe null
+            result.receiptId shouldBe "receipt-1"
+            result.amount shouldBe 1000.0
+            result.receiptName shouldBe "Test Receipt"
+            result.attachmentCount shouldBe 2
+            verify { attachmentService.getAttachmentsByReceiptId("receipt-1") }
+            verify { blobService.downloadImage("test-file.jpg") }
+        }
+
+        test("should return complete receipt with account number") {
+            // Given
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns null
+                every { accountNumber } returns "12345678901"
+                every { attachmentCount } returns 0L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            every { attachmentService.getAttachmentsByReceiptId("receipt-1") } returns emptyList()
+
+            // When
+            val result = receiptService.getCompleteReceipt(mockReceiptInfo)
+
+            // Then
+            result shouldNotBe null
+            result.paymentOrCard shouldBe "Payment"
+            result.paymentAccountNumber shouldBe "12345678901"
+            result.cardCardNumber shouldBe ""
+        }
+
+        test("should return complete receipt with card number") {
+            // Given
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 0L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            every { attachmentService.getAttachmentsByReceiptId("receipt-1") } returns emptyList()
+
+            // When
+            val result = receiptService.getCompleteReceipt(mockReceiptInfo)
+
+            // Then
+            result shouldNotBe null
+            result.paymentOrCard shouldBe "Card"
+            result.paymentAccountNumber shouldBe ""
+            result.cardCardNumber shouldBe "1234-5678-9012-3456"
+        }
+
+        test("should handle multiple attachments") {
+            // Given
+            val mockReceiptInfo = mockk<ReceiptInfo> {
+                every { receiptId } returns "receipt-1"
+                every { amount } returns 1000.0
+                every { receiptName } returns "Test Receipt"
+                every { receiptDescription } returns "Test Description"
+                every { receiptCreatedAt } returns LocalDateTime.now()
+                every { committeeName } returns "Test Committee"
+                every { userFullname } returns "Test User"
+                every { cardNumber } returns "1234-5678-9012-3456"
+                every { accountNumber } returns null
+                every { attachmentCount } returns 2L
+                every { latestReviewStatus } returns null
+                every { latestReviewCreatedAt } returns null
+                every { latestReviewComment } returns null
+            }
+            
+            val mockAttachment1 = mockk<Attachment> {
+                every { name } returns "test-file1.jpg"
+            }
+            val mockAttachment2 = mockk<Attachment> {
+                every { name } returns "test-file2.pdf"
+            }
+            
+            every { attachmentService.getAttachmentsByReceiptId("receipt-1") } returns listOf(mockAttachment1, mockAttachment2)
+            every { blobService.downloadImage("test-file1.jpg") } returns "base64data1"
+            every { blobService.downloadImage("test-file2.pdf") } returns "base64data2"
+
+            // When
+            val result = receiptService.getCompleteReceipt(mockReceiptInfo)
+
+            // Then
+            result shouldNotBe null
+            result.attachments.size shouldBe 2
+            verify { blobService.downloadImage("test-file1.jpg") }
+            verify { blobService.downloadImage("test-file2.pdf") }
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- Add and expand unit tests for core services to improve reliability and reach 80%+ coverage.

## Changes
- Add unit tests for most classes under the service package.

## Related Ticket
-  #67
